### PR TITLE
#18 Feat: 헤더/메뉴바 토글 연결 및 페이지 이동 구현

### DIFF
--- a/src/components/Layout/header/Header.js
+++ b/src/components/Layout/header/Header.js
@@ -1,18 +1,36 @@
+import React, { useState } from "react";
 import styled from "styled-components";
 import { TfiMenu } from "react-icons/tfi";
+import Menu from "../../menu/Menu";
 
 function Header() {
+  // 메뉴바 열기
+  const [isOpen, setIsOpen] = useState(false);
+  const onClickButton = () => {
+    setIsOpen(true);
+  };
+
   return (
-    <Container>
-      <TfiMenu className="menu-icon" />
-      <Logo
-        onClick={() => {
-          window.location.href = "/";
-        }}
-      >
-        TRAP
-      </Logo>
-    </Container>
+    <>
+      <Container>
+        <TfiMenu className="menu-icon" onClick={onClickButton} />
+        <Logo
+          onClick={() => {
+            window.location.href = "/";
+          }}
+        >
+          TRAP
+        </Logo>
+      </Container>
+      {isOpen && (
+        <Menu
+          open={isOpen}
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,6 +1,8 @@
+import React, { useState } from "react";
 import styled from "styled-components";
 import { TfiClose } from "react-icons/tfi";
 import { BsChevronRight } from "react-icons/bs";
+//import MenuCard from "./MenuCard";
 
 function Profile() {
   return (
@@ -25,24 +27,72 @@ function MenuCard({ menuName }) {
   );
 }
 
-function Menu() {
+function Menu({ onClose }) {
+  const handleClose = () => {
+    onClose?.();
+  };
+
   return (
     <>
       <Container>
         <Header>
-          <Logo>TRAP</Logo>
-          <TfiClose className="close-icon" />
+          <Logo
+            onClick={() => {
+              window.location.href = "/";
+            }}
+          >
+            TRAP
+          </Logo>
+          <span onClick={handleClose}>
+            <TfiClose className="close-icon" />
+          </span>
         </Header>
         <Profile />
         <MenuText>[ Menu ]</MenuText>
         <MenuBox>
-          <MenuCard menuName="쓰레기통 지도" />
-          <MenuCard menuName="쓰레기통 리스트" />
-          <MenuCard menuName="신고 및 건의하기" />
-          <MenuCard menuName="주요 처리 사례" />
-          <MenuCard menuName="마이페이지" />
+          <span
+            onClick={() => {
+              window.location.href = "/";
+            }}
+          >
+            <MenuCard menuName="쓰레기통 지도" />
+          </span>
+          <span
+            onClick={() => {
+              window.location.href = "/trashcan";
+            }}
+          >
+            <MenuCard menuName="쓰레기통 리스트" />
+          </span>
+          <span
+            onClick={() => {
+              window.location.href = "/report";
+            }}
+          >
+            <MenuCard menuName="신고 및 건의하기" />
+          </span>
+          <span
+            onClick={() => {
+              window.location.href = "/mainexample";
+            }}
+          >
+            <MenuCard menuName="주요 처리 사례" />
+          </span>
+          <span
+            onClick={() => {
+              window.location.href = "/mypage";
+            }}
+          >
+            <MenuCard menuName="마이페이지" />
+          </span>
         </MenuBox>
-        <LogInBox>로그인</LogInBox>
+        <LogInBox
+          onClick={() => {
+            window.location.href = "/login";
+          }}
+        >
+          로그인
+        </LogInBox>
       </Container>
     </>
   );
@@ -51,11 +101,15 @@ function Menu() {
 const Container = styled.div`
   border: 1px solid black;
   width: 250px;
-  height: 100%;
+  height: 100vh;
   position: fixed;
+  top: 0px;
+  left: 0px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  background-color: #ffffff;
+  z-index: 9999;
 `;
 
 const Header = styled.div`
@@ -66,10 +120,12 @@ const Header = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 0 15px 0 15px;
+  background-color: #ffffff;
 
   .close-icon {
     font-size: 30px;
     color: black;
+    cursor: pointer;
   }
 `;
 
@@ -77,6 +133,7 @@ const Logo = styled.span`
   font-size: 38px;
   font-weight: 700;
   color: #1d70b6;
+  cursor: pointer;
 `;
 
 const ProfileBox = styled.div`
@@ -132,6 +189,7 @@ const MenuInnerBox = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 999;
 `;
 
 const MenuName = styled.span`
@@ -152,6 +210,7 @@ const LogInBox = styled.div`
   font-weight: 700;
   position: fixed;
   bottom: 10px;
+  cursor: pointer;
 `;
 
 export default Menu;


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat#18

## 변경 사항
헤더와 메뉴바 토글 연결이 먼저 구현되면 개발 작업할 때 좋을 거 같아서 우선 제가 구현했어요!!

헤더의 토글 버튼 클릭시 메뉴바가 열리고 메뉴바의 X버튼 클릭시 닫힘 기능 구현했습니다. 
각 메뉴 페이지 이동 구현했습니다.
기능 구현하면서 최대한 코드에 지장 안가도록 조금씩 코드 수정했어요!

** 추가로 나중에 시간나면 메뉴바 열릴 때 서서히 나오고 닫히도록 애니메이션 적용하고, 화면 외부 클릭시 닫히도록 적용하면 좋을 것 같아요!

## 테스트 결과
![image](https://github.com/DS-Software-Engineering/front-end/assets/101581350/700ea8c5-2cb9-4a2b-a309-786b65230cf1)
